### PR TITLE
exposed original meetup id

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -35,6 +35,7 @@ exports.sourceNodes = (
     const nodeData = Object.assign({}, event, {
       ...event,
       id: nodeId,
+      meetupId: event.id,
       parent,
       children: [],
       internal: {


### PR DESCRIPTION
good for referencing that event from other plugins (e.g. to query image services, tweets, calendars by that meetup id)
using prepare hook in npm scripts (to build things also when using the github repo), see https://docs.npmjs.com/misc/scripts and compare gatsby root plugins like https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-contentful/package.json